### PR TITLE
 Adding number labels to axes

### DIFF
--- a/src/figure.rs
+++ b/src/figure.rs
@@ -81,6 +81,15 @@ where
         };
         let mut vertices = vec![];
         for point in points {
+            // If there are points outside the min and max range, skip over
+            // them since we won't draw them anyways.
+            if point.x > max_x
+                || point.x < min_x
+                || point.y > max_y
+                || point.y < min_y
+            {
+                continue;
+            }
             let error: f32 = 0.0;
             let x = if (max_x - min_x).abs() > error {
                 1.5 * (point.x - min_x) / (max_x - min_x) - 0.75

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,10 @@ fn main() {
     let handle = thread::spawn(move || {
         let mut figure = Figure::new()
             .init_renderer(10000)
+            .xlim([0.0, 1.0])
             .ylim([-10.0, 10.0])
             .xlabel("Time (s)")
-            .ylabel("Sin Stuff")
+            .ylabel("Amplitude")
             .color(0x80, 0x00, 0x80);
         loop {
             if !status {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,6 @@
 use crate::figure::FigureConfig;
-use glium::uniform;
 use glium::glutin::dpi::LogicalSize;
+use glium::uniform;
 use glium::{self, implement_vertex, Surface};
 use glium_text_rusttype as glium_text;
 use itertools_num::linspace;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -70,8 +70,8 @@ impl<'a> Renderer<'a> {
             .with_multisampling(2);
         let window = glium::glutin::WindowBuilder::new()
             .with_dimensions(LogicalSize {
-                width: 400.0,
-                height: 400.0,
+                width: 600.0,
+                height: 600.0,
             })
             .with_decorations(true)
             .with_title("Plot");
@@ -209,6 +209,59 @@ impl<'a> Renderer<'a> {
                 (0.0, 0.0, 0.0, 1.0),
             )
             .unwrap();
+        }
+        if let Some([xmin, xmax]) = config.xlim {
+            for (coord, tick) in
+                linspace(-0.75, 0.75, 6).zip(linspace(xmin, xmax, 6))
+            {
+                let tick_str = glium_text::TextDisplay::new(
+                    &self.text_system,
+                    &self.font,
+                    &format!("{:.02}", tick),
+                );
+                let text_width = tick_str.get_width() * 0.05;
+                #[rustfmt::skip]
+                let matrix = cgmath::Matrix4::new(
+                    0.05, 0.0, 0.0, 0.0,
+                    0.0, 0.05, 0.0, 0.0,
+                    0.0, 0.0, 0.05, 0.0,
+                    coord - text_width / 2.0, -0.80, 0.0, 1.0,
+                );
+                glium_text::draw(
+                    &tick_str,
+                    &self.text_system,
+                    target,
+                    matrix,
+                    (0.0, 0.0, 0.0, 1.0),
+                )
+                .unwrap();
+            }
+        }
+        if let Some([ymin, ymax]) = config.ylim {
+            for (coord, tick) in
+                linspace(-0.75, 0.75, 5).zip(linspace(ymin, ymax, 5))
+            {
+                let tick_str = glium_text::TextDisplay::new(
+                    &self.text_system,
+                    &self.font,
+                    &format!("{:.02}", tick),
+                );
+                #[rustfmt::skip]
+                let matrix = cgmath::Matrix4::new(
+                    0.05, 0.0, 0.0, 0.0,
+                    0.0, 0.05, 0.0, 0.0,
+                    0.0, 0.0, 0.05, 0.0,
+                    -0.85, coord, 0.0, 1.0,
+                );
+                glium_text::draw(
+                    &tick_str,
+                    &self.text_system,
+                    target,
+                    matrix,
+                    (0.0, 0.0, 0.0, 1.0),
+                )
+                .unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
- Numbers are written to the x and y axis for the given ticks. This
  currently only works if the limits for the given axes is set by the
  user. It currently doesn't work if we auto-scale.
- Fixed an issue where with manual limits we could erronenously draw
  outside the bounding box as we weren't culling points.
- Renderer now uses an orthographic projection to compensate for aspect
  ratio changes to keep a consistent view of the graph.

Closes #3.