### PR TITLE
Feature/complex samples

### DIFF
--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -24,7 +24,7 @@ fn main() {
                 .take(10)
                 .map(|x| x as f32)
                 .collect();
-            figure.plot_samples(&v);
+            figure.plot_stream(&v);
 
             let events_loop = match figure.renderer {
                 Some(ref mut rend) => &mut rend.events_loop,

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -1,6 +1,6 @@
+use rand::distributions::{Distribution, Normal};
 use rtplot::figure::{Figure, PlotType};
 use std::thread;
-use rand::distributions::{Distribution, Normal};
 
 fn main() {
     let mut status = true;
@@ -19,7 +19,11 @@ fn main() {
                 break;
             }
 
-            let v: Vec<f32> = normal.sample_iter(&mut rng).take(10).map(|x| x as f32).collect();
+            let v: Vec<f32> = normal
+                .sample_iter(&mut rng)
+                .take(10)
+                .map(|x| x as f32)
+                .collect();
             figure.plot_samples(&v);
 
             let events_loop = match figure.renderer {

--- a/examples/qpsk.rs
+++ b/examples/qpsk.rs
@@ -35,7 +35,7 @@ fn main() {
             }
 
             let symbol = generate_symbol();
-            figure.plot_complex_samples(&[symbol]);
+            figure.plot_complex_stream(&[symbol]);
 
             let events_loop = match figure.renderer {
                 Some(ref mut rend) => &mut rend.events_loop,

--- a/src/figure.rs
+++ b/src/figure.rs
@@ -153,7 +153,7 @@ impl<'a> Figure<'a> {
         self.plot(&points);
     }
 
-    pub fn plot_samples<T>(&mut self, y_coords: &[T])
+    pub fn plot_stream<T>(&mut self, y_coords: &[T])
     where
         T: Into<f32> + Copy,
     {
@@ -182,7 +182,7 @@ impl<'a> Figure<'a> {
         }
     }
 
-    pub fn plot_complex_samples(&mut self, points: &[Complex<f32>]) {
+    pub fn plot_complex_stream(&mut self, points: &[Complex<f32>]) {
         if self.complex_samples.len() >= self.config.num_points + points.len() {
             for _ in 0..self.complex_samples.len() - self.config.num_points
                 + points.len()

--- a/src/figure.rs
+++ b/src/figure.rs
@@ -4,7 +4,6 @@ use cgmath::Point2;
 use itertools_num::linspace;
 use num::Complex;
 use slice_deque::SliceDeque;
-use std::marker::PhantomData;
 
 pub enum PlotType {
     Line,
@@ -29,26 +28,20 @@ pub struct FigureConfig<'a> {
 }
 
 #[derive(Default)]
-pub struct Figure<'a, T>
-where
-    T: Into<f32> + Copy,
-{
+pub struct Figure<'a> {
     pub renderer: Option<Renderer<'a>>,
     pub config: FigureConfig<'a>,
     pub samples: SliceDeque<f32>,
-    _phantom: PhantomData<T>,
+    pub complex_samples: SliceDeque<Complex<f32>>,
 }
 
-impl<'a, T> Figure<'a, T>
-where
-    T: Into<f32> + Copy,
-{
+impl<'a> Figure<'a> {
     pub fn new() -> Self {
         Figure {
             renderer: None,
             config: FigureConfig::default(),
             samples: SliceDeque::new(),
-            _phantom: PhantomData,
+            complex_samples: SliceDeque::new(),
         }
     }
     pub fn init_renderer(mut self, num_points: usize) -> Self {
@@ -89,10 +82,7 @@ where
         self
     }
 
-    fn normalize(&self, points: &[Point2<f32>]) -> Vec<Vertex>
-    where
-        T: Into<f32> + Copy,
-    {
+    fn normalize(&self, points: &[Point2<f32>]) -> Vec<Vertex> {
         let [min_x, max_x] = match self.config.xlim {
             Some(lim) => lim,
             None => utils::calc_xlims(points),
@@ -139,7 +129,7 @@ where
     }
 
     /// Take an array of points and draw it to the screen.
-    pub fn plot_xy(&mut self, points: &[(T, T)])
+    pub fn plot_xy<T>(&mut self, points: &[(T, T)])
     where
         T: Into<f32> + Copy,
     {
@@ -151,7 +141,7 @@ where
     }
 
     /// Take an array of y coordinates, interpolate the x, and then plot.
-    pub fn plot_y(&mut self, y_coords: &[T])
+    pub fn plot_y<T>(&mut self, y_coords: &[T])
     where
         T: Into<f32> + Copy,
     {
@@ -163,7 +153,7 @@ where
         self.plot(&points);
     }
 
-    pub fn plot_samples(&mut self, y_coords: &[T])
+    pub fn plot_samples<T>(&mut self, y_coords: &[T])
     where
         T: Into<f32> + Copy,
     {
@@ -178,14 +168,10 @@ where
         for point in &y {
             self.samples.push_back(*point);
         }
-        let x_coords = linspace(
-            -0.5f32,
-            0.5f32,
-            self.config.num_points,
-        );
+        let x_coords = linspace(-0.5f32, 0.5f32, self.config.num_points);
         let points: Vec<Point2<f32>> = x_coords
             .zip(self.samples.iter())
-            .map(|(x, y)| Point2::new(x, (*y).into()))
+            .map(|(x, y)| Point2::new(x, *y))
             .collect();
         let vertices = self.normalize(&points);
         match self.renderer {
@@ -196,7 +182,32 @@ where
         }
     }
 
-    pub fn plot_complex(&mut self, coords: &[Complex<T>])
+    pub fn plot_complex_samples(&mut self, points: &[Complex<f32>]) {
+        if self.complex_samples.len() >= self.config.num_points + points.len() {
+            for _ in 0..self.complex_samples.len() - self.config.num_points
+                + points.len()
+            {
+                self.complex_samples.pop_front();
+            }
+        }
+        for point in points {
+            self.complex_samples.push_back(*point);
+        }
+        let points: Vec<Point2<f32>> = self
+            .complex_samples
+            .iter()
+            .map(|x| Point2::new(x.re, x.im))
+            .collect();
+        let vertices = self.normalize(&points);
+        match self.renderer {
+            Some(ref mut render) => {
+                render.draw(&vertices, &self.config);
+            }
+            None => panic!("Uninitialized renderer for figure"),
+        }
+    }
+
+    pub fn plot_complex<T>(&mut self, coords: &[Complex<T>])
     where
         T: Into<f32> + Copy,
     {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -143,6 +143,18 @@ impl<'a> Renderer<'a> {
             projection: *ortho,
         };
         self.vertex_buffer.invalidate();
+
+        let mut target = self.display.draw();
+        target.clear_color(0.8, 0.8, 0.8, 1.0);
+        // If there are no vertices provided during this draw, draw the axes
+        // and stop.
+        if vertices.is_empty() {
+            self.draw_axis(&mut target);
+            self.draw_text(&mut target, config);
+
+            target.finish().unwrap();
+            return;
+        }
         let vb = match self.vertex_buffer.slice_mut(0..vertices.len()) {
             Some(slice) => slice,
             None => return,
@@ -154,8 +166,6 @@ impl<'a> Renderer<'a> {
         };
         let indices = glium::index::NoIndices(plot_type);
 
-        let mut target = self.display.draw();
-        target.clear_color(0.8, 0.8, 0.8, 1.0);
         let vb = self.vertex_buffer.slice(0..vertices.len()).unwrap();
         target
             .draw(


### PR DESCRIPTION
- Added another queue in the structure for holding Complex samples for
  streaming purposes. As there's no way to keep both normal samples and
  Complex samples in one structure, this may cause us to change Figure
  stuff around to reduce redundancy.
- Added plot_complex_samples as a way to plot complex data via a stream.
- Removed trait bounds on Figure as it got in the way of Complex
  support.
- Added an example to show complex plotting via a stream: qpsk.rs.