### PR TITLE
Adding a new method to handle the display and event loops

### DIFF
--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -3,7 +3,6 @@ use rtplot::{Figure, PlotType};
 use std::thread;
 
 fn main() {
-    let mut status = true;
     let handle = thread::spawn(move || {
         let normal = Normal::new(0.0, 1.0);
         let mut rng = rand::thread_rng();
@@ -14,19 +13,15 @@ fn main() {
             .ylabel("Amplitude")
             .plot_type(PlotType::Line)
             .color(0x80, 0x00, 0x80);
-        loop {
-            if !status {
-                break;
-            }
 
+        Figure::display(figure, |fig| {
             let v: Vec<f32> = normal
                 .sample_iter(&mut rng)
                 .take(10)
                 .map(|x| x as f32)
                 .collect();
-            status = figure.handle_events();
-            figure.plot_stream(&v);
-        }
+            fig.plot_stream(&v);
+        });
     });
 
     handle.join().unwrap();

--- a/examples/qpsk.rs
+++ b/examples/qpsk.rs
@@ -21,7 +21,6 @@ fn generate_symbol() -> Complex<f32> {
 }
 
 fn main() {
-    let mut status = true;
     let handle = thread::spawn(move || {
         let mut figure = Figure::new()
             .init_renderer(10000)
@@ -29,15 +28,10 @@ fn main() {
             .ylim([-1.0, 1.0])
             .plot_type(PlotType::Dot)
             .color(0x50, 0x20, 0x50);
-        loop {
-            if !status {
-                break;
-            }
-
+        Figure::display(figure, |fig| {
             let symbol = generate_symbol();
-            status = figure.handle_events();
-            figure.plot_complex_stream(&[symbol]);
-        }
+            fig.plot_complex_stream(&[symbol]);
+        });
     });
 
     handle.join().unwrap();

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -13,7 +13,6 @@ fn calculate_sin(phase: f32) -> Vec<f32> {
 
 fn main() {
     let mut phase = 0.0;
-    let mut status = true;
     let handle = thread::spawn(move || {
         let mut figure = Figure::new()
             .init_renderer(10000)
@@ -23,16 +22,12 @@ fn main() {
             .ylabel("Amplitude")
             .plot_type(PlotType::Dot)
             .color(0x80, 0x00, 0x80);
-        loop {
-            if !status {
-                break;
-            }
 
+        Figure::display(figure, |fig| {
             let sin_vals = calculate_sin(phase);
-            status = figure.handle_events();
-            figure.plot_y(&sin_vals);
+            fig.plot_y(&sin_vals);
             phase += PI / 20.0;
-        }
+        });
     });
 
     handle.join().unwrap();

--- a/src/figure.rs
+++ b/src/figure.rs
@@ -306,4 +306,16 @@ impl<'a> Figure<'a> {
             .collect();
         self.plot(&points);
     }
+
+    /// Hijacks the current thread to run the plotting and event loop.
+    pub fn display(mut figure: Figure, mut plot_fn: impl FnMut(&mut Figure)) {
+        let mut status = true;
+        loop {
+            if !status {
+                break;
+            }
+            status = figure.handle_events();
+            plot_fn(&mut figure);
+        }
+    }
 }


### PR DESCRIPTION
- New method on Figure to run a closure that receives and plots data
  while handling events. This way users don't have to worry about
  forgetting to call handle_events and having their window not be able
  to close.
- Examples updated to use Figure::display.