### PR TITLE
Moving from handcrafted rendering to lyon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2018"
 [dependencies]
 glium = "0.22"
 cgmath = "0.17"
-glium_text_rusttype = "0.3"
+glium_text_rusttype = "0.3.2"
+lyon = "0.14"
+lyon_path = "0.14"
 itertools-num = "0.1"
 num = "0.2"
-ttf-noto-sans = "0.1"
 slice-deque = "0.1"
+ttf-noto-sans = "0.1"
 
 [dev-dependencies]
 rand = "0.6"

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -7,7 +7,7 @@ fn main() {
         let normal = Normal::new(0.0, 1.0);
         let mut rng = rand::thread_rng();
         let mut figure = Figure::new()
-            .init_renderer(100)
+            .init_window(100)
             .ylim([-1.0, 1.0])
             .xlabel("Time (s)")
             .ylabel("Amplitude")

--- a/examples/qpsk.rs
+++ b/examples/qpsk.rs
@@ -23,7 +23,7 @@ fn generate_symbol() -> Complex<f32> {
 fn main() {
     let handle = thread::spawn(move || {
         let mut figure = Figure::new()
-            .init_renderer(10000)
+            .init_window(10000)
             .xlim([-1.0, 1.0])
             .ylim([-1.0, 1.0])
             .plot_type(PlotType::Dot)

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -4,7 +4,7 @@ use std::f32::consts::PI;
 use std::thread;
 
 fn calculate_sin(phase: f32) -> Vec<f32> {
-    let sin_vals: Vec<_> = linspace(0.0, 100.0, 10000)
+    let sin_vals: Vec<_> = linspace(0.0, 100.0, 1000)
         .map(|x| 10.0 * (PI / 8.0 * x as f32 + phase).sin())
         .collect();
 
@@ -15,13 +15,13 @@ fn main() {
     let mut phase = 0.0;
     let handle = thread::spawn(move || {
         let mut figure = Figure::new()
-            .init_renderer(10000)
+            .init_window(10000)
             .xlim([-0.5, 0.5])
             .ylim([-10.0, 10.0])
             .xlabel("Time (s)")
             .ylabel("Amplitude")
-            .plot_type(PlotType::Dot)
-            .color(0x80, 0x00, 0x80);
+            .plot_type(PlotType::Line)
+            .color(0xFF, 0x00, 0x00);
 
         Figure::display(&mut figure, |fig| {
             let sin_vals = calculate_sin(phase);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 
 mod figure;
-mod renderer;
+mod window;
 mod utils;
 
 pub use figure::{Figure, FigureConfig, PlotType};


### PR DESCRIPTION
- For ease of creating plots and future extendability, we've moved to
  lyon for rendering instead of the handcrafted implementation of the
  past.
- Renderer has been renamed to Window for better understanding of what
  it's doing and what it represents.
- Added a grid by default for the plot.
- Changed the background color to a gray to hurt the eyes less.