### PR TITLE
Feature/api cleanup

### DIFF
--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -6,8 +6,7 @@ fn main() {
     let handle = thread::spawn(move || {
         let normal = Normal::new(0.0, 1.0);
         let mut rng = rand::thread_rng();
-        let mut figure = Figure::new()
-            .init_window(100)
+        let mut figure = Figure::new(100)
             .ylim([-1.0, 1.0])
             .xlabel("Time (s)")
             .ylabel("Amplitude")

--- a/examples/qpsk.rs
+++ b/examples/qpsk.rs
@@ -22,8 +22,7 @@ fn generate_symbol() -> Complex<f32> {
 
 fn main() {
     let handle = thread::spawn(move || {
-        let mut figure = Figure::new()
-            .init_window(10000)
+        let mut figure = Figure::new(10000)
             .xlim([-1.0, 1.0])
             .ylim([-1.0, 1.0])
             .plot_type(PlotType::Dot)

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -14,8 +14,7 @@ fn calculate_sin(phase: f32) -> Vec<f32> {
 fn main() {
     let mut phase = 0.0;
     let handle = thread::spawn(move || {
-        let mut figure = Figure::new()
-            .init_window(10000)
+        let mut figure = Figure::new(10000)
             .xlim([-0.5, 0.5])
             .ylim([-10.0, 10.0])
             .xlabel("Time (s)")

--- a/src/figure.rs
+++ b/src/figure.rs
@@ -1,5 +1,5 @@
-use crate::window::{Vertex, Window};
 use crate::utils;
+use crate::window::{Vertex, Window};
 use cgmath::Point2;
 use itertools_num::linspace;
 use num::Complex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 
 mod figure;
-mod window;
 mod utils;
+mod window;
 
 pub use figure::{Figure, FigureConfig, PlotType};

--- a/src/window.rs
+++ b/src/window.rs
@@ -242,7 +242,7 @@ impl<'a> Window<'a> {
         target.finish().expect("Could not finish the frame");
     }
 
-    pub fn draw_text<S>(&mut self, target: &mut S, config: &FigureConfig)
+    fn draw_text<S>(&mut self, target: &mut S, config: &FigureConfig)
     where
         S: glium::Surface,
     {

--- a/src/window.rs
+++ b/src/window.rs
@@ -173,7 +173,7 @@ impl<'a> Window<'a> {
         let mut target = self.display.draw();
         let color = (169.0 / 255.0, 169.0 / 255.0, 169.0 / 255.0, 1.0);
         target.clear_color_and_depth(color, 1.0);
-        let mut mesh: VertexBuffers<Vertex, u16> = VertexBuffers::new();
+        let mut mesh: VertexBuffers<Vertex, u32> = VertexBuffers::new();
         self.draw_text(&mut target, config);
         self.draw_grid(&mut mesh);
 
@@ -193,7 +193,7 @@ impl<'a> Window<'a> {
                         VertexCtor(config.color, ZDepth::Near),
                     ),
                 )
-                .unwrap();
+                .expect("Could not draw line plot");
             }
             PlotType::Dot => {
                 for point in points {
@@ -206,7 +206,7 @@ impl<'a> Window<'a> {
                             VertexCtor(config.color, ZDepth::Near),
                         ),
                     )
-                    .unwrap();
+                    .expect("Could not draw dot plot");
                 }
             }
         }
@@ -220,13 +220,14 @@ impl<'a> Window<'a> {
         };
 
         let vertex_buffer =
-            glium::VertexBuffer::new(&self.display, &mesh.vertices).unwrap();
+            glium::VertexBuffer::new(&self.display, &mesh.vertices)
+                .expect("Could not create vertex buffer");
         let indices = glium::IndexBuffer::new(
             &self.display,
             glium::index::PrimitiveType::TrianglesList,
             &mesh.indices,
         )
-        .unwrap();
+        .expect("Could not create index buffer");
 
         target
             .draw(
@@ -236,9 +237,9 @@ impl<'a> Window<'a> {
                 &uniforms,
                 &self.draw_parameters,
             )
-            .unwrap();
+            .expect("Could not draw the frame");
 
-        target.finish().unwrap();
+        target.finish().expect("Could not finish the frame");
     }
 
     pub fn draw_text<S>(&mut self, target: &mut S, config: &FigureConfig)
@@ -269,7 +270,7 @@ impl<'a> Window<'a> {
                 matrix,
                 (0.0, 0.0, 0.0, 1.0),
             )
-            .unwrap();
+            .expect("Could not draw x label");
         }
         if let Some(text) = config.ylabel {
             let label = glium_text::TextDisplay::new(
@@ -292,7 +293,7 @@ impl<'a> Window<'a> {
                 matrix,
                 (0.0, 0.0, 0.0, 1.0),
             )
-            .unwrap();
+            .expect("Could not draw y label");
         }
         if let Some([xmin, xmax]) = config.xlim {
             for (coord, tick) in
@@ -318,7 +319,7 @@ impl<'a> Window<'a> {
                     matrix,
                     (0.0, 0.0, 0.0, 1.0),
                 )
-                .unwrap();
+                .expect("Could not draw x axis values");
             }
         }
         if let Some([ymin, ymax]) = config.ylim {
@@ -345,12 +346,12 @@ impl<'a> Window<'a> {
                     matrix,
                     (0.0, 0.0, 0.0, 1.0),
                 )
-                .unwrap();
+                .expect("Could not draw y axis labels");
             }
         }
     }
 
-    fn draw_grid(&mut self, mesh: &mut VertexBuffers<Vertex, u16>) {
+    fn draw_grid(&mut self, mesh: &mut VertexBuffers<Vertex, u32>) {
         let mut tessellator = FillTessellator::new();
 
         for tick in linspace(-0.75, 0.75, 6) {
@@ -370,7 +371,7 @@ impl<'a> Window<'a> {
                     VertexCtor([0x5d, 0x5d, 0x5d], ZDepth::Far),
                 ),
             )
-            .unwrap();
+            .expect("Could not draw grid");
         }
 
         for tick in linspace(-0.75, 0.75, 5) {
@@ -390,7 +391,7 @@ impl<'a> Window<'a> {
                     VertexCtor([0x5d, 0x5d, 0x5d], ZDepth::Far),
                 ),
             )
-            .unwrap();
+            .expect("Could not draw grid");
         }
 
         stroke_quad(


### PR DESCRIPTION
Changes to remove redundancy in the API and more documentation

- num_points in src/figure.rs has been renamed to queue_size and moved
  from FigureConfig to Figure since it isn't an optional field and we
  don't want to try to pick a default here.
- Removed init_window. The window is now created when calling
  Figure::new() or Figure::new_with_config(). The window field on Figure
  is no longer an Option.
- Renamed handle_events to should_close_window to better match its use.
- Made some fields that shouldn't be exposed in the API private.
- The number of vertices by default was too small for a lot of our use
  cases, so the index type has been bumped up from a u16 to a u32.
- More useful panic messages have been added.
- Fixed documentation on FigureConfig so it'll generate properly.